### PR TITLE
Update tsq-gallery version to 1.2.9

### DIFF
--- a/projects/tsq-gallery/package.json
+++ b/projects/tsq-gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@townsquad/tsq-gallery",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Angular file preview and carrousel viewer for images and pdfs.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The main change of this new version refers to the update of `ng2-pdf-viewer` to version `6.4.1`:
- https://github.com/townsquad/tsq-gallery/pull/37